### PR TITLE
Update launch UI button

### DIFF
--- a/ofdsqgisplugin/button_custom_ui.svg
+++ b/ofdsqgisplugin/button_custom_ui.svg
@@ -1,57 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   width="24"
-   height="24"
-   viewBox="0 0 24 24"
-   fill="none"
-   version="1.1"
-   id="svg8"
-   sodipodi:docname="button_custom_ui.svg"
-   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs12" />
-  <sodipodi:namedview
-     id="namedview10"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     showgrid="false"
-     inkscape:zoom="41.666667"
-     inkscape:cx="12.036"
-     inkscape:cy="12"
-     inkscape:window-width="1499"
-     inkscape:window-height="1209"
-     inkscape:window-x="26"
-     inkscape:window-y="23"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg8" />
-  <rect
-     width="24"
-     height="24"
-     fill="white"
-     id="rect2" />
-  <rect
-     x="2"
-     y="2"
-     width="20"
-     height="20"
-     rx="2"
-     fill="#0C1031"
-     id="rect4" />
-  <path
-     d="M10 16.4L6 12.4L7.4 11L10 13.6L16.6 7L18 8.4L10 16.4Z"
-     fill="white"
-     id="path6" />
-  <path
-     d="m 10.676937,16.537906 4,-4 -1.399999,-1.4 -2.6,2.6 -6.6000005,-6.5999997 -1.4,1.4 z"
-     fill="#ffffff"
-     id="path172" />
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_14_17)">
+<rect width="24" height="24" fill="white"/>
+<rect x="2" y="2" width="20" height="20" rx="2" fill="#0C1031"/>
+<path d="M5.6 19C5.16 19 4.78347 18.841 4.4704 18.5231C4.1568 18.2046 4 17.8219 4 17.375V7.625C4 7.17812 4.1568 6.79571 4.4704 6.47775C4.78347 6.15925 5.16 6 5.6 6H18.4C18.84 6 19.2168 6.15925 19.5304 6.47775C19.8435 6.79571 20 7.17812 20 7.625V17.375C20 17.8219 19.8435 18.2046 19.5304 18.5231C19.2168 18.841 18.84 19 18.4 19H5.6ZM5.6 17.375H18.4V9.25H5.6V17.375Z" fill="white"/>
+</g>
+<defs>
+<clipPath id="clip0_14_17">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
 </svg>


### PR DESCRIPTION
Chosen the 'window' icon over 'play' or 'rocket launch', as this seemed to fit in with design sensibilities of the plugin. 